### PR TITLE
Auto width instead of 100% width.

### DIFF
--- a/src/render_wikitext.rs
+++ b/src/render_wikitext.rs
@@ -117,7 +117,6 @@ impl RendererWikitext {
                     if list.template_params().wdedit {
                         wt += " wd_can_edit";
                     }
-                    wt += "' style='width:100%'\n";
                     list.columns()
                         .iter()
                         .enumerate()


### PR DESCRIPTION
Browser will make the table as big as needed.