### PR TITLE
fix: add .gitignore with target/ and config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Cargo folder
+target/
+
+# Specific configuration
+config.json


### PR DESCRIPTION
Adds a .gitignore to ignore cargo compilation folder `target/` and local specific configuration `config.json`