### PR TITLE
Use Coordinates module instead of coord template on enwiki

### DIFF
--- a/config.json.template
+++ b/config.json.template
@@ -15,7 +15,8 @@
         "default":"{{Coord|$LAT$|$LON$|display=inline}}",
         "wikidatawiki":"$LAT$/$LON$",
         "commonswiki":"{{Inline coordinates|$LAT$|$LON$|display=inline}}",
-        "dewiki":"{{Coordinate|text=DMS|NS=$LAT$|EW=$LON$|name=$ITEM$|simple=y|type=landmark|region=$REGION$}}"
+        "dewiki":"{{Coordinate|text=DMS|NS=$LAT$|EW=$LON$|name=$ITEM$|simple=y|type=landmark|region=$REGION$}}",
+        "enwiki":"{{#invoke:Coordinates|coord|$LAT$|$LON$|display=inline}}"
     },
     "wiki_login": {
         "user": "XXX",


### PR DESCRIPTION
Using the {{coord}} template has a high post-expand include size overhead and is causing pages to exceed the limit. This change can also apply to other wikis, but I'm not sure which other ones have either migrated to Lua or imported the template after the 2013 enwiki migration of the template.