### PR TITLE
Fix Module:Cite web to use correct syntax with two pipes.

### DIFF
--- a/src/reference.rs
+++ b/src/reference.rs
@@ -101,9 +101,9 @@ impl Reference {
     }
 
     fn render_cite_web(&self, use_invoke: bool, list: &ListeriaList) -> String {
-        let template = if use_invoke { "{{#invoke:" } else { "{{" };
+        let template = if use_invoke { "{{#invoke:cite web|" } else { "{{cite web" };
         let mut ret = format!(
-            "{template}cite web|url={}|title={}",
+            "{template}|url={}|title={}",
             self.url.as_ref().unwrap_or(&String::new()),
             self.title.as_ref().unwrap_or(&String::new())
         );


### PR DESCRIPTION
Should work on all wikis that have the module and fix bug #141. The fix in #128 could probably be reverted, as long as Module:Cite web is invoked with two pipes.

Please see the documentation for Module:Cite web:
_This module may be placed directly on articles by replacing {{Cite web| with {{#invoke:Cite web|| (note the double pipe)._